### PR TITLE
Update enketo HPA api to v2

### DIFF
--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,5 +1,6 @@
+{{ $kubeVersion := substr 0 5 .Capabilities.KubeVersion.Version }}
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.23" $kubeVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta1
@@ -21,7 +22,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23" $kubeVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
@@ -33,7 +34,7 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare ">=1.23" $kubeVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "enketo.fullname" . }}
@@ -17,12 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else -}}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else -}}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -21,11 +21,11 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-        {{- else -}}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
         {{- end }}
     {{- end }}
@@ -33,11 +33,11 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion -}}
+        {{- if semverCompare ">=1.23" .Capabilities.KubeVersion.GitVersion }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
-        {{- else -}}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
         {{- end }}
     {{- end }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -1,6 +1,5 @@
-{{ $kubeVersion := substr 0 5 .Capabilities.KubeVersion.Version }}
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.23" $kubeVersion -}}
+{{- if and (ge 1 (.Capabilities.KubeVersion.Major|int))  (ge 23 (.Capabilities.KubeVersion.Minor|int)) -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta1
@@ -22,7 +21,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        {{- if semverCompare ">=1.23" $kubeVersion }}
+        {{- if and (ge 1 (.Capabilities.KubeVersion.Major|int))  (ge 23 (.Capabilities.KubeVersion.Minor|int)) }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
@@ -34,7 +33,7 @@ spec:
     - type: Resource
       resource:
         name: memory
-        {{- if semverCompare ">=1.23" $kubeVersion }}
+        {{- if and (ge 1 (.Capabilities.KubeVersion.Major|int))  (ge 23 (.Capabilities.KubeVersion.Minor|int)) }}
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}


### PR DESCRIPTION
- Update HPA API to v2 and update resource metrics manifest
- Add backward compatibility with k8s versions lower than 1.23.x