### PR TITLE
add hostalias

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,5 +3,5 @@ name: enketo
 description: A Helm chart for enketo-express
 home: https://github.com/enketo/enketo-express
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "7.0.0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,6 +29,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,14 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+hostAliases: []
+#   - ip: "<ip>"
+#     hostnames:
+#       - "<hostname>"
+#   - ip: "<ip>"
+#     hostnames:
+#       - "<hostname1>"
+#       - "<hostname2>"
 podAnnotations: {}
 
 podSecurityContext:


### PR DESCRIPTION
For environments where DNS resolution is unreliable or not configured as needed, the capability to manually specify DNS entries, akin to the functionality provided by /etc/hosts, proves to be beneficial. Incorporating hostAliases enables us to achieve this flexibility.